### PR TITLE
Enable variable expansion in input xml <column> nodes, and allow html injection in table body

### DIFF
--- a/benchexec/model.py
+++ b/benchexec/model.py
@@ -607,7 +607,8 @@ class Run():
             self.status = self.runSet.benchmark.tool.determine_result(returncode, returnsignal, output, isTimeout)
         self.category = result.get_result_category(self.identifier, self.status, self.properties)
         for column in self.columns:
-            column.value = self.runSet.benchmark.tool.get_value_from_output(output, column.text)
+            substitutedColumnText = substitute_vars([column.text], self.runSet, self.sourcefiles[0])[0]
+            column.value = self.runSet.benchmark.tool.get_value_from_output(output, substitutedColumnText)
 
 
         # Tools sometimes produce a result even after a timeout.

--- a/benchexec/tablegenerator/template.html
+++ b/benchexec/tablegenerator/template.html
@@ -205,7 +205,7 @@ def format_options(str):
 <td class="status {{runResult.category}}">{{(value or '-').lower()}}</td>
     {{endif}}
   {{else}}
-<td class="{{runResult.category}} value">{{format_value(value, column)}}</td>
+<td class="{{runResult.category}} value">{{format_value(value, column)|html}}</td>
   {{endif}}
   {{endfor}}
   {{endfor}}


### PR DESCRIPTION
These changes were made for the SMACK team to add a link to some intermediate output files that SMACK generates, which contain details about each of our benchmark runs.

After looking at how minor and general the changes were, I thought it might be useful to the community in general, without any crazy changes to the way things are working.

(If you're interested, variables get substituted into <column> pattern, which get passed as 'identifier' to the get_value_from_output() function of objects inheriting the Tool class.  This overridden function then uses the expanded variables to create links to download the intermediate files)